### PR TITLE
feat: 점령한 장소 이미지 마커 처리

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -45,7 +45,7 @@ const MountainMapScreen = () => {
   }, []);
 
   // 폴리곤 클릭 이벤트 처리 핸들러
-  const handleClickPolygon = async (challengeId: number) => {
+  const handleClickPolygon = async (challengeId: number, isChallenged:boolean) => {
     try {
       const data = await fetchChallengeInfo(challengeId);
 
@@ -59,6 +59,7 @@ const MountainMapScreen = () => {
         condition1: stripBracket(data[0].condition1),
         condition2: stripBracket(data[0].condition2),
         condition3: stripBracket(data[0].condition3),
+        isChallenged: isChallenged,
       };
 
       setSelectedChallengeInfo(parsedData as ChallengeInformation);

--- a/components/template/MapTemplate.tsx
+++ b/components/template/MapTemplate.tsx
@@ -8,7 +8,7 @@ interface MapTemplateProps {
   // 맵의 폴리곤을 띄우기 위해 필요한 지역별 챌린지 데이터 배열
   challengeLocationData: ChallengeLocation[];
   // 폴리곤 클릭시 -> place 이름을 전달하며 바텀시트 open trigger
-  handleClickPolygon: (challengeId: number) => void;
+  handleClickPolygon: (challengeId: number, isChallenged:boolean) => void;
   // 현재 유저의 위치
   userLocation: Coord | null;
   // 초기 위치가 정해져 있는 경우 해당 위치 (검색 클릭한 경우)
@@ -31,16 +31,18 @@ export default function MapTemplate({
     if (initialCoord) {
       mapRef.current?.animateCameraTo({
         ...initialCoord,
-        zoom: 16,
+        zoom: 13,
         animation: 'easeIn',
       });
     }
   }, [initialCoord]);
 
-  // TODO: 달성한 챌린지는 사진 마커 렌더링
+  const doneChallenge= challengeLocationData.filter((item)=>item.isChallenged);
+  const notDoneChallenge = challengeLocationData.filter((item)=>!item.isChallenged)
 
   return (
     <NaverMapView
+
       pointerEvents={modalOpen ? 'none' : 'auto'}
       ref={mapRef}
       style={styles.container}
@@ -59,7 +61,7 @@ export default function MapTemplate({
       }
       isExtentBoundedInKorea={true}
     >
-      {challengeLocationData.map(item => {
+      {notDoneChallenge.map(item => {
         return (
           <View key={item.place}>
             {/* Polygon 그리기*/}
@@ -67,7 +69,7 @@ export default function MapTemplate({
               key={`${item.place}-polygon`}
               coords={item.location} // 위도, 경도값 전달
               onTap={() => {
-                handleClickPolygon(item.challengeId);
+                handleClickPolygon(item.challengeId, item.isChallenged);
               }}
               outlineWidth={3}
               outlineColor={MCOLORS.brand.secondary}
@@ -91,6 +93,13 @@ export default function MapTemplate({
             />
           </View>
         );
+      })}
+      {doneChallenge.map((item)=>{
+        return (
+        <NaverMapMarkerOverlay onTap={() => {
+                handleClickPolygon(item.challengeId, item.isChallenged);
+              }} image={{httpUri: item.challengePhoto}} key={item.challengeId} width={100} height={100} latitude={item.center.latitude} longitude={item.center.longitude}>
+</NaverMapMarkerOverlay>)
       })}
     </NaverMapView>
   );

--- a/components/template/map/BottomSheetTemplate.tsx
+++ b/components/template/map/BottomSheetTemplate.tsx
@@ -118,9 +118,12 @@ export default function BottomSheetTemplate({
         </View>
 
         {/* 하단 버튼 영역 */}
-        <View style={styles.btnContainer}>
-          <PrimaryButton kind={getKind(stepPayloads)} text={text} onPress={() => nextStep()} />
+         <View style={styles.btnContainer}>
+          {challengeInfo.isChallenged ? <PrimaryButton kind={'normal-dismiss'} text={"점령 완료"} onPress={() => {}} /> : <PrimaryButton kind={getKind(stepPayloads)} text={text} onPress={() => nextStep()} />}
+          
+             
         </View>
+       
       </Animated.View>
     </SafeAreaView>
   );

--- a/types/challenge.ts
+++ b/types/challenge.ts
@@ -13,6 +13,7 @@ export type ChallengeInformation = {
   condition2: string; // 조건 2
   condition3?: string; // 조건 3 (선택적 데이터)
   isFavorite: boolean; // 관심 장소 등록 여부
+  isChallenged: boolean; // 챌린지 수행 여부
 };
 
 // 챌린지 위치 타입


### PR DESCRIPTION
## #️⃣연관된 이슈

#15 

## 📝작업 내용

점령 완료 장소 이미지 마커 처리를 했습니다.
점령 완료 장소를 누르면 바텀 시트가 열리며, 임시로 점령 완료를 띄웠습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
