### PR TITLE
feat: usePointStore 포인트 상태 관리 훅 구현 & 앨범 포인트 사용 로직 적용

### DIFF
--- a/components/common/PriceTag.tsx
+++ b/components/common/PriceTag.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Image, StyleSheet, Text, View } from "react-native";
+import React from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
 
 interface PriceTagProps {
   /** 가격 */
@@ -12,10 +12,7 @@ interface PriceTagProps {
 export default function PriceTag({ price }: PriceTagProps) {
   return (
     <View style={styles.wrapper}>
-      <Image
-        source={require("@/assets/images/album/icon-coins.png")}
-        style={styles.coin}
-      />
+      <Image source={require('@/assets/images/album/icon-coins.png')} style={styles.coin} />
       <Text style={styles.price}>{price}</Text>
     </View>
   );
@@ -23,13 +20,22 @@ export default function PriceTag({ price }: PriceTagProps) {
 
 const styles = StyleSheet.create({
   wrapper: {
-    backgroundColor: "#F8F8F8",
+    backgroundColor: '#F8F8F8',
     borderRadius: 100,
     paddingHorizontal: 10,
     paddingVertical: 5,
-    flexDirection: "row",
-    alignItems: "center",
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: 4,
+
+    // iOS
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.1,
+
+    // Android
+    elevation: 4,
   },
   coin: {
     width: 20,
@@ -37,7 +43,7 @@ const styles = StyleSheet.create({
   },
   price: {
     fontSize: 13,
-    color: "#4A4A4A",
-    fontWeight: "500",
+    color: '#4A4A4A',
+    fontWeight: '500',
   },
 });

--- a/components/template/AlbumShareTemplate.tsx
+++ b/components/template/AlbumShareTemplate.tsx
@@ -4,8 +4,10 @@ import { PrimaryButton } from '@/components/common/Button/PrimaryButton';
 import PriceTag from '@/components/common/PriceTag';
 import { TopBar } from '@/components/common/TopBar';
 import { ButtonVariant } from '@/constants/buttonTypes';
+import { usePointStore } from '@/store/usePointStore';
 import { BadgeType, FrameType } from '@/types/shareType';
-import React from 'react';
+import { showCustomToast } from '@/utils/toastManager';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import ViewShot from 'react-native-view-shot';
 import { PolaroidPhoto } from '../album/_type';
@@ -60,9 +62,67 @@ const AlbumShareTemplate = React.forwardRef<ViewShot, AlbumShareTemplateProps>(
     },
     ref,
   ) => {
+    const { holdingPoint, fetchPointHistory, updatePoint } = usePointStore();
+    const [isFinalizing, setIsFinalizing] = useState(false);
+
+    const framePrice = frameOptions?.find(f => f.type === selectedFrame)?.price || 0;
+    const badgePrice = badgeOptions?.find(b => b.type === selectedBadge)?.price || 0;
+    const totalCost = step === 1 ? framePrice : framePrice + badgePrice;
+
+    // UI에 표시될 예상 보유 포인트 (음수 가능, 적용해서 프리뷰는 되고 / 다음 핸들러 클릭 시, 사용 불가 모달 노출함)
+    const projectedPoints = holdingPoint - totalCost;
+    const displayPoints = isFinalizing ? holdingPoint : projectedPoints;
+
+    const handleConfirm = async () => {
+      // '다음' 버튼 - 포인트 확인만 수행
+      if (step === 1) {
+        if (holdingPoint < framePrice) {
+          showCustomToast('포인트가 부족해요');
+          return;
+        }
+        onNext();
+        return;
+      }
+
+      // '공유하기' 버튼 - 최종 포인트 확인 및 API 호출
+      if (step === 2) {
+        const finalCost = framePrice + badgePrice;
+        if (holdingPoint < finalCost) {
+          showCustomToast('포인트가 부족해요');
+          return;
+        }
+
+        if (finalCost > 0) {
+          setIsFinalizing(true);
+          try {
+            let content = '';
+            if (framePrice > 0 && badgePrice > 0) content = '프레임 및 뱃지 사용';
+            else if (framePrice > 0) content = '프레임 사용';
+            else if (badgePrice > 0) content = '뱃지 사용';
+
+            await updatePoint({
+              pointEarned: 0,
+              pointUsed: finalCost,
+              content,
+            });
+          } catch (error) {
+            console.error('포인트 차감에 실패했습니다:', error);
+            setIsFinalizing(false);
+            return;
+          }
+        }
+
+        onShare();
+      }
+    };
+
+    useEffect(() => {
+      fetchPointHistory();
+    }, [fetchPointHistory]);
+
     return (
       <View style={styles.page}>
-        <TopBar title="" rightButton={<PriceTag price={800} />} />
+        <TopBar title="" rightButton={<PriceTag price={displayPoints} />} />
         <View style={styles.container}>
           <ViewShot ref={ref} options={{ fileName: 'polaroid-share', format: 'png', quality: 1.0 }}>
             <CustomPolaroid photo={photo} frame={selectedFrame} badge={selectedBadge} />
@@ -98,6 +158,7 @@ const AlbumShareTemplate = React.forwardRef<ViewShot, AlbumShareTemplateProps>(
                       label={b.label}
                       badgeType={b.type}
                       selected={selectedBadge === b.type}
+                      price={b.price}
                       onPress={type => onChangeBadge(type as BadgeType)}
                     />
                   ))}
@@ -108,7 +169,7 @@ const AlbumShareTemplate = React.forwardRef<ViewShot, AlbumShareTemplateProps>(
           <PrimaryButton
             text={step === 1 ? '다음' : '공유하기'}
             variant={ButtonVariant.Primary}
-            onPress={step === 1 ? onNext : onShare}
+            onPress={handleConfirm}
           />
         </View>
       </View>

--- a/store/usePointStore.ts
+++ b/store/usePointStore.ts
@@ -1,0 +1,66 @@
+import { getMyPointHistory, patchPointHistory } from '@/api/mypage';
+import { MyPointHistoryItem, MyPointHistoryRequest } from '@/api/type';
+import { create } from 'zustand';
+
+interface PointState {
+  holdingPoint: number;
+  pointLogs: MyPointHistoryItem[];
+  isLoading: boolean;
+  error: string | null;
+  fetchPointHistory: () => Promise<void>;
+  updatePoint: (data: MyPointHistoryRequest) => Promise<void>;
+}
+
+export const usePointStore = create<PointState>((set, get) => ({
+  holdingPoint: 0,
+  pointLogs: [],
+  isLoading: false,
+  error: null,
+
+  /**
+   * 전체 포인트 내역을 서버에서 가져와 상태를 업데이트하는 액션
+   */
+  fetchPointHistory: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await getMyPointHistory();
+
+      if (response.isSuccess) {
+        const { holdingPoint, pointLogs } = response.result;
+        set({
+          holdingPoint,
+          pointLogs,
+          isLoading: false,
+        });
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (e) {
+      const err = e as Error;
+      set({ error: err.message, isLoading: false });
+      console.error('Failed to fetch point history:', err);
+    }
+  },
+
+  /**
+   * 포인트를 사용하거나 적립하고, 최신 내역으로 다시고침하는 액션
+   * @param {MyPointHistoryRequest} data - 포인트 변경 내용
+   */
+  updatePoint: async (data: MyPointHistoryRequest) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await patchPointHistory(data);
+
+      if (response.isSuccess) {
+        await get().fetchPointHistory();
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (e) {
+      const err = e as Error;
+      set({ error: err.message, isLoading: false });
+      console.error('Failed to update point:', err);
+      throw e;
+    }
+  },
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈

#74 

## 📝작업 내용

- 포인트 `PriceTag` 스타일 수정
- usePointStore 훅 구현: 현재 포인트 조회 및 히스토리, 패치 모두 확인 가능
  - `const { holdingPoint, fetchPointHistory, updatePoint } = usePointStore();` 
- 앨범 공유하기 프레임/뱃지 선택 로직 적용
  - 탑바 포인트 내역: UI에 표시될 예상 보유 포인트로 음수도 가능함
    - 옵션 클릭해서 프리뷰는 되고 > 다음 핸들러 클릭 시, 사용 불가 모달 노출함
    - 공유하기 최종 버튼 클릭 시, 사용 포인트에 대한 patch API 호출

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
