### PR TITLE
fix: 앨범 qa 반영

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -21,6 +21,7 @@ export default {
         NSLocationAlwaysUsageDescription: '항상 위치 권한을 요청하는 이유를 설명합니다. (필요한 경우에만 사용)',
         NSCameraUsageDescription: '사진을 촬영하려면 카메라 접근이 필요합니다.',
         NSPhotoLibraryUsageDescription: '사진을 선택하려면 앨범 접근이 필요합니다.',
+        LSApplicationQueriesSchemes: ['instagram-stories'],
       },
       useAppleSignIn: true,
       config: {
@@ -33,6 +34,11 @@ export default {
     android: {
       googleServicesFile: './google-services.json',
       package: 'com.mellog.deulseokzz',
+      queries: [
+        {
+          package: 'com.instagram.android',
+        },
+      ],
       adaptiveIcon: {
         foregroundImage: './assets/images/adaptive-icon.png',
         backgroundColor: '#ffffff',

--- a/app/(app)/album/[place]/edit.tsx
+++ b/app/(app)/album/[place]/edit.tsx
@@ -57,7 +57,7 @@ export default function AlbumEditScreen() {
     return undefined;
   }, [parsedPhoto, newImageUri]);
 
-  const isSaveEnabled = desc.trim().length > 0;
+  const isSaveEnabled = true;
 
   /** handler function */
   const handleSave = async () => {

--- a/app/(app)/album/[place]/edit.tsx
+++ b/app/(app)/album/[place]/edit.tsx
@@ -66,8 +66,8 @@ export default function AlbumEditScreen() {
         // --- 수정 모드 (PATCH) ---
         const requestBody = {
           photoId: Number(parsedPhoto.id),
-          feelings: selectedFeeling === '없음' ? undefined : selectedFeeling,
-          weather: selectedWeather === '없음' ? undefined : selectedWeather,
+          feelings: selectedFeeling === '없음' ? '' : selectedFeeling,
+          weather: selectedWeather === '없음' ? '' : selectedWeather,
           photoContent: desc,
           date: new Date(parsedPhoto.date).toISOString().split('T')[0],
         };
@@ -81,9 +81,9 @@ export default function AlbumEditScreen() {
         formData.append('photo', { uri: newImageUri, name: filename, type } as any);
         formData.append('place', placeParam);
         formData.append('date', new Date().toISOString().split('T')[0]);
-        selectedFeeling !== '없음' && formData.append('feelings', selectedFeeling);
-        selectedWeather !== '없음' && formData.append('weather', selectedWeather);
-        desc && formData.append('photoContent', desc);
+        formData.append('feelings', selectedFeeling === '없음' ? '' : selectedFeeling);
+        formData.append('weather', selectedWeather === '없음' ? '' : selectedWeather);
+        formData.append('photoContent', desc);
 
         const res = await postPhotoDataToAlbum(formData);
         if (!res.isSuccess) throw new Error(res.message);
@@ -126,9 +126,12 @@ export default function AlbumEditScreen() {
   /** lifecycle */
   useEffect(() => {
     if (parsedPhoto) {
-      setSelectedFeeling((parsedPhoto.additional.feeling as FeelingType) ?? '없음');
-      setSelectedWeather((parsedPhoto.additional.weather as WeatherType) ?? '없음');
-      setDesc(parsedPhoto.additional.desc ?? '');
+      const feelingFromServer = parsedPhoto.additional?.feeling;
+      const weatherFromServer = parsedPhoto.additional?.weather;
+
+      setSelectedFeeling((feelingFromServer as FeelingType) || '없음');
+      setSelectedWeather((weatherFromServer as WeatherType) || '없음');
+      setDesc(parsedPhoto.additional?.desc ?? '');
     }
   }, [parsedPhoto]);
 

--- a/app/(app)/album/[place]/edit.tsx
+++ b/app/(app)/album/[place]/edit.tsx
@@ -1,5 +1,6 @@
 import { patchPhotoToAlbum, postPhotoDataToAlbum } from '@/api/album';
 import { PolaroidPhoto } from '@/components/album/_type';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 import ModalManager from '@/components/common/Modal/ModalManager';
 import AlbumEditTemplate from '@/components/template/AlbumEditTemplate';
 import { ButtonVariant } from '@/constants/buttonTypes';
@@ -35,6 +36,7 @@ export default function AlbumEditScreen() {
   const [selectedFeeling, setSelectedFeeling] = useState<FeelingType>('없음');
   const [selectedWeather, setSelectedWeather] = useState<WeatherType>('없음');
   const [desc, setDesc] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
 
   /** hooks */
   const { show: showSaveModal, hide: hideSaveModal, ...saveModal } = useModal();
@@ -57,10 +59,14 @@ export default function AlbumEditScreen() {
     return undefined;
   }, [parsedPhoto, newImageUri]);
 
-  const isSaveEnabled = true;
+  const isSaveEnabled = !isLoading;
 
   /** handler function */
   const handleSave = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+
     try {
       if (parsedPhoto) {
         // --- 수정 모드 (PATCH) ---
@@ -101,6 +107,7 @@ export default function AlbumEditScreen() {
           text: '확인',
           onPress: () => {
             hideSaveModal();
+            setIsLoading(false);
             router.back();
           },
         },
@@ -108,6 +115,7 @@ export default function AlbumEditScreen() {
     } catch (e: any) {
       console.error('저장 실패:', e);
       Alert.alert('저장 실패', e.message || '오류가 발생했습니다.');
+      setIsLoading(false);
     }
   };
 
@@ -163,6 +171,7 @@ export default function AlbumEditScreen() {
         modalProps={cancelModal.modalProps}
         onClose={hideCancelModal}
       />
+      <LoadingSpinner isVisible={isLoading} />
     </>
   );
 }

--- a/app/(app)/album/[place]/index.tsx
+++ b/app/(app)/album/[place]/index.tsx
@@ -9,6 +9,7 @@ import ModalManager from '@/components/common/Modal/ModalManager';
 import AlbumIdTemplate from '@/components/template/AlbumIdTemplate';
 import { ModalType } from '@/enums/modalTypes';
 import useModal from '@/hooks/useModal';
+import useSortedPhotos from '@/hooks/useSortedPhotos';
 import { FeelingType } from '@/types/feeling';
 import { WeatherType } from '@/types/weather';
 import { Image } from 'expo-image';
@@ -27,17 +28,12 @@ export default function AlbumIdScreen() {
   const [photos, setPhotos] = useState<PolaroidPhoto[]>([]);
   const [activeIndex, setActiveIndex] = useState(0);
 
-  /** variable */
-  const selectedPhoto = photos[activeIndex];
-
   /** hooks */
-  const {
-    isShowing: isModalVisible,
-    modalType,
-    modalProps,
-    show: showModal,
-    hide: hideModal,
-  } = useModal();
+  const { isShowing: isModalVisible, modalType, modalProps, show: showModal, hide: hideModal } = useModal();
+  const sortedPhotos = useSortedPhotos(photos);
+
+  /** variable */
+  const selectedPhoto = sortedPhotos[activeIndex];
 
   /** API util */
   const transformPhoto = useCallback(
@@ -52,13 +48,12 @@ export default function AlbumIdScreen() {
           photo.people?.map(p => ({
             id: p.id,
             name: p.name,
-            avatar: p.uri
-              ? { uri: p.uri }
-              : require('@/assets/images/album/black-profile-small.png'),
+            avatar: p.uri ? { uri: p.uri } : require('@/assets/images/album/black-profile-small.png'),
           })) || [],
       },
       date: photo.date ?? '',
       loc: placeParam ?? '',
+      isFavorite: photo.isFavorite,
     }),
     [placeParam],
   );
@@ -124,10 +119,7 @@ export default function AlbumIdScreen() {
       showModal(ModalType.DEFAULT, {
         title: '대표 사진을 변경했어요',
         children: (
-          <Image
-            source={require('@/assets/images/modal/icon-picture.png')}
-            style={{ width: 80, height: 82 }}
-          />
+          <Image source={require('@/assets/images/modal/icon-picture.png')} style={{ width: 80, height: 82 }} />
         ),
         buttons: {
           text: '확인',
@@ -182,7 +174,7 @@ export default function AlbumIdScreen() {
   return (
     <>
       <AlbumIdTemplate
-        photos={photos}
+        photos={sortedPhotos}
         activeIndex={activeIndex}
         setActiveIndex={setActiveIndex}
         albumTitle={placeParam || ''}
@@ -197,12 +189,7 @@ export default function AlbumIdScreen() {
           { label: '사진 삭제', onPress: handleDelete },
         ]}
       />
-      <ModalManager
-        isShowing={isModalVisible}
-        modalType={modalType}
-        modalProps={modalProps}
-        onClose={hideModal}
-      />
+      <ModalManager isShowing={isModalVisible} modalType={modalType} modalProps={modalProps} onClose={hideModal} />
     </>
   );
 }

--- a/app/(app)/album/[place]/index.tsx
+++ b/app/(app)/album/[place]/index.tsx
@@ -64,8 +64,8 @@ export default function AlbumIdScreen() {
       const res = await getAlbumByPlace(placeParam);
       if (res.isSuccess) {
         const transformed = res.result.map(transformPhoto);
-        setActiveIndex(0); //캐러셀 맨 앞 카드로
         setPhotos(transformed);
+        setActiveIndex(0);
       }
     } catch (e) {
       console.error('API 호출 실패', e);
@@ -174,6 +174,7 @@ export default function AlbumIdScreen() {
   return (
     <>
       <AlbumIdTemplate
+        key={photos.length > 0 ? photos.map(p => p.id).join('-') : 'initial'}
         photos={sortedPhotos}
         activeIndex={activeIndex}
         setActiveIndex={setActiveIndex}

--- a/app/(app)/album/delete/index.tsx
+++ b/app/(app)/album/delete/index.tsx
@@ -6,6 +6,7 @@ import AlbumDeleteTemplate from '@/components/template/AlbumDeleteTemplate';
 import { ButtonVariant } from '@/constants/buttonTypes';
 import { ModalType } from '@/enums/modalTypes';
 import useModal from '@/hooks/useModal';
+import useSortedPhotos from '@/hooks/useSortedPhotos';
 import { FeelingType } from '@/types/feeling';
 import { WeatherType } from '@/types/weather';
 import { showCustomToast } from '@/utils/toastManager';
@@ -25,6 +26,7 @@ export default function AlbumDeleteScreen() {
 
   /** hooks */
   const { isShowing: isModalVisible, modalType, modalProps, show: showModal, hide: hideModal } = useModal();
+  const sortedPhotos = useSortedPhotos(photos);
 
   /** API util */
   const transformPhoto = (photo: PhotoItem): PolaroidPhoto => ({
@@ -112,7 +114,7 @@ export default function AlbumDeleteScreen() {
       <AlbumDeleteTemplate
         albumTitle={placeParam || ''}
         selectedPhotos={selectedPhotos}
-        photos={photos}
+        photos={sortedPhotos}
         onSelectPhoto={handleSelect}
         onPressDelete={handleDeletePress}
       />

--- a/components/album/CustomPolaroid.tsx
+++ b/components/album/CustomPolaroid.tsx
@@ -38,7 +38,6 @@ export default function CustomPolaroid({ photo, frame, badge }: PolaroidProps & 
             <View style={styles.metaRow}>
               {feelingIcon && <Image source={feelingIcon} style={styles.metaIcon} />}
               {weatherIcon && <Image source={weatherIcon} style={styles.metaIcon} />}
-              {!feelingIcon && !weatherIcon && <Text style={[styles.metaFallback, textColor]}>없음</Text>}
             </View>
 
             <Text style={[styles.desc, textColor]} numberOfLines={2}>

--- a/components/album/PhotoSelector.tsx
+++ b/components/album/PhotoSelector.tsx
@@ -1,6 +1,6 @@
 import { PolaroidPhoto } from '@/components/album/_type';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import PhotoItem, { PhotoType } from './PhotoItem';
 
 interface PhotoSelectorProps {
@@ -20,44 +20,41 @@ interface PhotoSelectorProps {
  * - 최대 선택 가능한 사진 개수 제한
  */
 export default function PhotoSelector({ photos, selectedPhotos, onSelectPhoto, maxSelectCnt }: PhotoSelectorProps) {
+  const renderPhotoItem = ({ item: photo }: { item: PolaroidPhoto }) => {
+    let type: PhotoType = 'normal';
+    const isSelected = selectedPhotos.some(p => p.id === photo.id);
+
+    if (photo.isFavorite) {
+      type = 'dimmed'; // 대표 사진은 항상 비활성화
+    } else if (isSelected) {
+      type = 'selected';
+    } else if (selectedPhotos.length >= maxSelectCnt) {
+      type = 'dimmed';
+    }
+
+    return (
+      <View style={styles.itemWrapper}>
+        <PhotoItem image={photo.image} type={type} isFavorite={photo.isFavorite} onPress={() => onSelectPhoto(photo)} />
+      </View>
+    );
+  };
+
   return (
-    <View style={styles.grid}>
-      {photos.map((photo, index) => {
-        let type: PhotoType = 'normal';
-        const isSelected = selectedPhotos.some(p => p.id === photo.id);
-
-        if (photo.isFavorite) {
-          type = 'dimmed'; // 대표 사진은 항상 비활성화
-        } else if (isSelected) {
-          type = 'selected';
-        } else if (selectedPhotos.length >= maxSelectCnt) {
-          type = 'dimmed';
-        }
-
-        return (
-          <View key={index} style={styles.itemWrapper}>
-            <PhotoItem
-              image={photo.image}
-              type={type}
-              isFavorite={photo.isFavorite}
-              onPress={() => onSelectPhoto(photo)}
-            />
-          </View>
-        );
-      })}
-    </View>
+    <FlatList
+      data={photos}
+      renderItem={renderPhotoItem}
+      keyExtractor={item => item.id.toString()}
+      numColumns={3}
+      style={styles.grid}
+    />
   );
 }
 
 const styles = StyleSheet.create({
   grid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
     width: '100%',
   },
   itemWrapper: {
-    width: '31%',
-    marginBottom: 10,
+    flex: 1 / 3,
   },
 });

--- a/components/album/Polaroid.tsx
+++ b/components/album/Polaroid.tsx
@@ -21,7 +21,6 @@ export default function Polaroid({ photo }: PolaroidProps) {
         <View style={styles.metaRow}>
           {feelingIcon && <Image source={feelingIcon} style={styles.metaIcon} />}
           {weatherIcon && <Image source={weatherIcon} style={styles.metaIcon} />}
-          {!feelingIcon && !weatherIcon && <Text style={styles.metaFallback}>없음</Text>}
         </View>
 
         <Text style={styles.desc} numberOfLines={2}>

--- a/components/common/LoadingSpinner.tsx
+++ b/components/common/LoadingSpinner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+
+interface LoadingSpinnerProps {
+  /** 스피너가 표시될지 여부 */
+  isVisible: boolean;
+  /** 스피너의 색상 (기본값: 멜로그 브랜드 컬러 #F76F8E) */
+  color?: string;
+}
+
+/**
+ * 전체 화면을 덮는 오버레이와 함께 로딩 스피너를 표시하는 컴포넌트
+ */
+export default function LoadingSpinner({ isVisible, color = '#F76F8E' }: LoadingSpinnerProps) {
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <View style={styles.overlay}>
+      <ActivityIndicator size="large" color={color} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1000,
+  },
+});

--- a/components/template/AlbumEditTemplate.tsx
+++ b/components/template/AlbumEditTemplate.tsx
@@ -5,19 +5,8 @@ import { TopBar } from '@/components/common/TopBar';
 import { ButtonVariant } from '@/constants/buttonTypes';
 import { FeelingType } from '@/types/feeling';
 import { WeatherType } from '@/types/weather';
-import React from 'react';
-import {
-  Image,
-  KeyboardAvoidingView,
-  Platform,
-  SafeAreaView,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from 'react-native';
-
+import React, { useRef } from 'react';
+import { Image, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 interface AlbumEditTemplateProps {
   isSaveEnabled?: boolean;
   imageSource: any;
@@ -64,11 +53,13 @@ export default function AlbumEditTemplate({
   onSave,
   onCancel,
 }: AlbumEditTemplateProps) {
+  const scrollViewRef = useRef<ScrollView>(null);
+
   return (
-    <SafeAreaView style={styles.page}>
+    <View style={styles.page}>
       <TopBar title="" />
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <ScrollView ref={scrollViewRef} contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
           <Image source={imageSource} style={styles.mainImage} />
           <View style={styles.input_container}>
             <EmojiSelector<FeelingType>
@@ -93,6 +84,11 @@ export default function AlbumEditTemplate({
                 value={desc}
                 onChangeText={onChangeDesc}
                 maxLength={100}
+                onFocus={() => {
+                  setTimeout(() => {
+                    scrollViewRef.current?.scrollToEnd({ animated: true });
+                  }, 200);
+                }}
               />
               <Text style={styles.charCounter}>{`${desc.length} / 100`}</Text>
             </View>
@@ -107,10 +103,9 @@ export default function AlbumEditTemplate({
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
-    </SafeAreaView>
+    </View>
   );
 }
-
 const styles = StyleSheet.create({
   page: {
     flex: 1,

--- a/components/template/AlbumEditTemplate.tsx
+++ b/components/template/AlbumEditTemplate.tsx
@@ -6,7 +6,17 @@ import { ButtonVariant } from '@/constants/buttonTypes';
 import { FeelingType } from '@/types/feeling';
 import { WeatherType } from '@/types/weather';
 import React from 'react';
-import { Image, StyleSheet, TextInput, View } from 'react-native';
+import {
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 
 interface AlbumEditTemplateProps {
   isSaveEnabled?: boolean;
@@ -55,43 +65,49 @@ export default function AlbumEditTemplate({
   onCancel,
 }: AlbumEditTemplateProps) {
   return (
-    <View style={styles.page}>
+    <SafeAreaView style={styles.page}>
       <TopBar title="" />
-      <View style={styles.container}>
-        <Image source={imageSource} style={styles.mainImage} />
-        <View style={styles.input_container}>
-          <EmojiSelector<FeelingType>
-            label="기분"
-            options={feelings}
-            selected={selectedFeeling}
-            onSelect={onChangeFeeling}
-            imageMap={feelingImageMap}
-          />
-          <EmojiSelector<WeatherType>
-            label="날씨"
-            options={weathers}
-            selected={selectedWeather}
-            onSelect={onChangeWeather}
-            imageMap={weatherImageMap}
-          />
-          <TextInput
-            style={styles.input}
-            multiline
-            placeholder="오늘은 무슨 일이 있었나요?"
-            value={desc}
-            onChangeText={onChangeDesc}
-          />
-        </View>
-        <View style={styles.buttonContainer}>
-          <PrimaryButton variant={ButtonVariant.Subtle} text="취소" onPress={onCancel} />
-          <PrimaryButton
-            variant={isSaveEnabled ? ButtonVariant.Primary : ButtonVariant.Disable}
-            text="저장"
-            onPress={onSave}
-          />
-        </View>
-      </View>
-    </View>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
+        <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+          <Image source={imageSource} style={styles.mainImage} />
+          <View style={styles.input_container}>
+            <EmojiSelector<FeelingType>
+              label="기분"
+              options={feelings}
+              selected={selectedFeeling}
+              onSelect={onChangeFeeling}
+              imageMap={feelingImageMap}
+            />
+            <EmojiSelector<WeatherType>
+              label="날씨"
+              options={weathers}
+              selected={selectedWeather}
+              onSelect={onChangeWeather}
+              imageMap={weatherImageMap}
+            />
+            <View>
+              <TextInput
+                style={styles.input}
+                multiline
+                placeholder="오늘은 무슨 일이 있었나요?"
+                value={desc}
+                onChangeText={onChangeDesc}
+                maxLength={100}
+              />
+              <Text style={styles.charCounter}>{`${desc.length} / 100`}</Text>
+            </View>
+          </View>
+          <View style={styles.buttonContainer}>
+            <PrimaryButton variant={ButtonVariant.Subtle} text="취소" onPress={onCancel} />
+            <PrimaryButton
+              variant={isSaveEnabled ? ButtonVariant.Primary : ButtonVariant.Disable}
+              text="저장"
+              onPress={onSave}
+            />
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
 
@@ -101,17 +117,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   container: {
-    flex: 1,
-    flexDirection: 'column',
+    flexGrow: 1,
     paddingHorizontal: 20,
     paddingBottom: 20,
-    gap: 30,
-    width: '100%',
     alignItems: 'center',
-    backgroundColor: '#fff',
+    justifyContent: 'space-evenly',
   },
   input_container: {
-    flex: 1,
     flexDirection: 'column',
     width: '100%',
     gap: 15,
@@ -125,14 +137,26 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9F9F9',
     borderRadius: 20,
     height: 200,
+    paddingBottom: 30,
     padding: 20,
     fontSize: 15,
     lineHeight: 20,
     color: '#333',
+    textAlignVertical: 'top',
   },
   buttonContainer: {
     display: 'flex',
     flexDirection: 'row',
     gap: 18,
+    marginTop: 10,
+    width: '100%',
+    justifyContent: 'center',
+  },
+  charCounter: {
+    position: 'absolute',
+    bottom: 10,
+    right: 15,
+    color: '#999',
+    fontSize: 12,
   },
 });

--- a/components/template/AlbumIdTemplate.tsx
+++ b/components/template/AlbumIdTemplate.tsx
@@ -35,14 +35,7 @@ interface Props {
 /**
  * 앨범 상세 보기 템플릿
  */
-export default function AlbumIdTemplate({
-  photos,
-  activeIndex,
-  setActiveIndex,
-  albumTitle,
-  actions,
-  menu,
-}: Props) {
+export default function AlbumIdTemplate({ photos, activeIndex, setActiveIndex, albumTitle, actions, menu }: Props) {
   const [dropdownVisible, setDropdownVisible] = useState(false);
 
   const openMenu = () => setDropdownVisible(true);
@@ -59,6 +52,7 @@ export default function AlbumIdTemplate({
         <TopBar title={albumTitle} rightButton={<IcnMore />} onRightPress={openMenu} />
         <View style={styles.container}>
           <PhotoSetCarousel
+            key={photos.length > 0 ? photos.map(p => p.id).join('-') : 'initial'}
             photos={photos}
             activeIndex={activeIndex}
             setActiveIndex={setActiveIndex}

--- a/hooks/useInstagramShare.ts
+++ b/hooks/useInstagramShare.ts
@@ -1,4 +1,4 @@
-import { Alert, Platform } from 'react-native';
+import { Alert, Linking, Platform } from 'react-native';
 import Share from 'react-native-share';
 import ViewShot from 'react-native-view-shot';
 
@@ -13,28 +13,61 @@ export const useInstagramShare = (ref: React.RefObject<ViewShot | null>) => {
   const share = async () => {
     try {
       const uri = await ref.current?.capture?.();
-
-      if (uri) {
-        const stickerImageUri = Platform.OS === 'ios' ? `file://${uri}` : uri;
-
-        const shareOptions = {
-          social: Share.Social.INSTAGRAM_STORIES,
-          appId: META_APP_ID,
-          stickerImage: stickerImageUri,
-          backgroundTopColor: STORY_BACKGROUND_COLOR,
-          backgroundBottomColor: STORY_BACKGROUND_COLOR,
-        };
-
-        await Share.shareSingle(shareOptions as any);
-      } else {
+      if (!uri) {
         Alert.alert('오류', '이미지를 캡처하는 데 실패했습니다. 다시 시도해주세요.');
+        return;
       }
+
+      const stickerImageUri = `file://${uri}`;
+
+      // 공유를 시도하기 전에 먼저 인스타그램 설치 여부를 확인
+      let isInstagramInstalled = false;
+      if (Platform.OS === 'android') {
+        const result = await Share.isPackageInstalled('com.instagram.android');
+        isInstagramInstalled = result.isInstalled;
+      } else if (Platform.OS === 'ios') {
+        isInstagramInstalled = await Linking.canOpenURL('instagram-stories://share');
+      }
+
+      // 인스타그램이 설치되어 있지 않다면, 스토어로 안내
+      if (!isInstagramInstalled) {
+        Alert.alert('Instagram이 필요해요', '스토리에 공유하려면 Instagram 앱이 설치되어야 합니다.', [
+          { text: '취소', style: 'cancel' },
+          {
+            text: '스토어로 이동',
+            onPress: () => {
+              const storeUrl =
+                Platform.OS === 'ios'
+                  ? 'itms-apps://itunes.apple.com/app/id389801252'
+                  : 'https://play.google.com/store/apps/details?id=com.instagram.android';
+
+              Linking.openURL(storeUrl).catch(err => {
+                console.error('스토어 이동 실패:', err);
+                Alert.alert('오류', '스토어를 여는 데 실패했습니다.');
+              });
+            },
+          },
+        ]);
+        return;
+      }
+
+      const shareOptions = {
+        social: Share.Social.INSTAGRAM_STORIES,
+        appId: META_APP_ID,
+        stickerImage: stickerImageUri,
+        backgroundTopColor: STORY_BACKGROUND_COLOR,
+        backgroundBottomColor: STORY_BACKGROUND_COLOR,
+      };
+
+      await Share.shareSingle(shareOptions as any);
     } catch (error: any) {
-      if (error.message.includes('User did not share')) {
+      console.error('스토리 공유 중 오류 발생:', error);
+      const errorMessage = String(error.message).toLowerCase();
+
+      if (errorMessage.includes('user did not share')) {
         console.log('사용자가 공유를 취소했습니다.');
       } else {
-        console.error('스토리 공유 중 오류 발생:', error);
-        Alert.alert('오류', '스토리를 공유하는 중 문제가 발생했습니다. 인스타그램 앱이 설치되어 있는지 확인해주세요.');
+        Alert.alert('오류', '스토리를 공유하는 중 문제가 발생했습니다.');
       }
     }
   };

--- a/hooks/useSortedPhotos.ts
+++ b/hooks/useSortedPhotos.ts
@@ -1,0 +1,32 @@
+import { PolaroidPhoto } from '@/components/album/_type';
+import { useMemo } from 'react';
+
+/**
+ * PolaroidPhoto 배열을 받아 대표 사진(isFavorite)이 항상 맨 앞에 오도록 정렬하는 훅
+ * @param photos - 원본 사진 배열
+ * @returns 정렬된 사진 배열
+ */
+const useSortedPhotos = (photos: PolaroidPhoto[]): PolaroidPhoto[] => {
+  const sortedPhotos = useMemo(() => {
+    const photosCopy = [...photos];
+
+    photosCopy.sort((a, b) => {
+      // a가 대표 사진이고 b는 아닐 경우, a를 앞으로 보냄
+      if (a.isFavorite && !b.isFavorite) {
+        return -1;
+      }
+      // b가 대표 사진이고 a는 아닐 경우, b를 앞으로 보냄
+      if (!b.isFavorite && a.isFavorite) {
+        return 1;
+      }
+      // 둘 다 대표 사진이거나 둘 다 아닐 경우, 순서를 바꾸지 않음
+      return 0;
+    });
+
+    return photosCopy;
+  }, [photos]);
+
+  return sortedPhotos;
+};
+
+export default useSortedPhotos;

--- a/ios/Mellog/Info.plist
+++ b/ios/Mellog/Info.plist
@@ -55,6 +55,7 @@
       <string>instagram</string>
       <string>instagram-stories</string>
       <string>instagramstories</string>
+      <string>itms-apps</string>
     </array>
     <key>LSMinimumSystemVersion</key>
     <string>12.0</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

#90 

## 📝작업 내용

- 앨범 수정 시 ios&android에서 키보드 안 내려가는 문제 > 스크롤뷰 및 키보드 위치 대비
- 대표사진 항상 앞에오게 정렬 > `useSortedPhotos.ts` 훅 구현 및 적용
- 앨범 수정 일기 텍스트 입력창 시작이 왼쪽 상단이 아닌 중간에서 시작하는 문제 > 안드로이드 속성 적용
- 앨범 사진 추가 시 로딩 UI 추가 > `LoadingSpinner` 컴포넌트 구현 및 적용
- 사진 인스타 공유 해결 > 인스타그램 앱 없으면 app store, play store 이동 / 있으면 스토리 공유
- 앨범 사진 삭제 시 ui 문제, 대표사진 변경 시 캐러셀 맨 앞으로 보냄 > 캐러셀 내부 키값 강제 새로고침 하도록 변경 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

공용 로딩 스피너 컴포넌트 만들어놧으니 필요시 쓰세욤.
