### PR TITLE
feat: 링크를 통한 친구 추가 및 요청 수락 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,10 +34,10 @@
         <data android:scheme="exp+mellog"/>
       </intent-filter>
       <intent-filter android:autoVerify="true" data-generated="true">
-        <action android:name="android.intent.action.VIEW"/>
-        <data android:scheme="https" android:host="deulsseokz.github.io" android:pathPrefix="/Mellog.github.io/"/>
+        <action android:name="android.intent.action.VIEW"/>  
         <category android:name="android.intent.category.BROWSABLE"/>
         <category android:name="android.intent.category.DEFAULT"/>
+        <data android:scheme="https" android:host="mellog.vercel.app" android:pathPrefix="/invite"/>
       </intent-filter>
     </activity>
     <provider android:name="androidx.core.content.FileProvider" android:authorities="${applicationId}.provider" android:exported="false" android:grantUriPermissions="true">

--- a/api/myPageDTO.ts
+++ b/api/myPageDTO.ts
@@ -9,6 +9,7 @@
 import { CommonResponse, deleteRequest, getRequest, patchRequest } from './common';
 import {
   FriendProfileResponse,
+  InviteLinkResponse,
   MyFriendListResponse,
   MyPageFixRequest,
   MyPageItem,
@@ -16,7 +17,7 @@ import {
   MyPointHistoryResponse,
   PatchCloseFriendRequest,
   RegionConquerRateResponse,
-   RegionConquerStatusResponse
+  RegionConquerStatusResponse,
 } from './type';
 
 /**
@@ -64,9 +65,8 @@ export async function patchPointHistory(body: MyPointHistoryRequest): Promise<Co
  * @description 지역별 챌린지 정복률 조회
  * @returns {Promise<CommonResponse<RegionConquerRateResponse>>} 지역별 정복률 정보를 포함한 응답
  */
-export async function getChallengeLocal(
-) : Promise<CommonResponse<RegionConquerRateResponse>> {
-    return await getRequest<RegionConquerRateResponse>(`/challenge/local`);
+export async function getChallengeLocal(): Promise<CommonResponse<RegionConquerRateResponse>> {
+  return await getRequest<RegionConquerRateResponse>(`/challenge/local`);
 }
 
 /**
@@ -74,9 +74,8 @@ export async function getChallengeLocal(
  * @description 지역 내 장소별 챌린지 정복 여부 조회
  * @returns {Promise<CommonResponse<RegionConquerStatusResponse>>} 지역별 챌린지 정복 현황 정보를 포함한 응답
  */
-export async function getChallengeCompletion(
-): Promise<CommonResponse<RegionConquerStatusResponse>> {
-    return await getRequest<RegionConquerStatusResponse>(`/challenge/completion`);
+export async function getChallengeCompletion(): Promise<CommonResponse<RegionConquerStatusResponse>> {
+  return await getRequest<RegionConquerStatusResponse>(`/challenge/completion`);
 }
 
 /**
@@ -117,4 +116,13 @@ export async function deleteMyFriend(friendId: number): Promise<CommonResponse<n
 
 export async function patchCloseFriend(body: PatchCloseFriendRequest): Promise<CommonResponse<null>> {
   return await patchRequest<null, PatchCloseFriendRequest>(`/friends/close`, body);
+}
+
+/**
+ * @function getInviteLink
+ * @description 초대 링크 조회
+ * @returns {Promise<CommonResponse<InviteLinkResponse>>} - API 응답 메시지
+ */
+export async function getInviteLink(): Promise<CommonResponse<InviteLinkResponse>> {
+  return await getRequest<InviteLinkResponse>(`/friends/invite`);
 }

--- a/api/myPageDTO.ts
+++ b/api/myPageDTO.ts
@@ -6,8 +6,9 @@
  */
 
 /**************************************************************/
-import { CommonResponse, deleteRequest, getRequest, patchRequest } from './common';
+import { CommonResponse, deleteRequest, getRequest, patchRequest, postRequest } from './common';
 import {
+  AcceptInviteRequest,
   FriendProfileResponse,
   InviteLinkResponse,
   MyFriendListResponse,
@@ -125,4 +126,14 @@ export async function patchCloseFriend(body: PatchCloseFriendRequest): Promise<C
  */
 export async function getInviteLink(): Promise<CommonResponse<InviteLinkResponse>> {
   return await getRequest<InviteLinkResponse>(`/friends/invite`);
+}
+
+/**
+ * @function postInviteCode
+ * @description 초대 링크 수락
+ * @param {string} inviteCode - 초대 코드
+ * @returns {Promise<CommonResponse<null>>} - API 응답 메시지
+ */
+export async function postInviteCode(body: AcceptInviteRequest): Promise<CommonResponse<string>> {
+  return await postRequest<string, AcceptInviteRequest>(`/friends/invite/open`, body);
 }

--- a/api/type.ts
+++ b/api/type.ts
@@ -343,3 +343,7 @@ export interface ChallengeResultItem {
   condition2: boolean;
   condition3: boolean;
 }
+
+export interface InviteLinkResponse {
+  url: string;
+}

--- a/api/type.ts
+++ b/api/type.ts
@@ -347,3 +347,7 @@ export interface ChallengeResultItem {
 export interface InviteLinkResponse {
   url: string;
 }
+
+export interface AcceptInviteRequest {
+  code: string;
+}

--- a/app.config.js
+++ b/app.config.js
@@ -30,6 +30,7 @@ export default {
       entitlements: {
         'aps-environment': 'production',
       },
+      associatedDomains: ['applinks:mellog.vercel.app'],
     },
     android: {
       googleServicesFile: './google-services.json',
@@ -52,8 +53,8 @@ export default {
           data: [
             {
               scheme: 'https',
-              host: 'deulsseokz.github.io',
-              pathPrefix: '/Mellog.github.io/',
+              host: 'mellog.vercel.app',
+              pathPrefix: '/invite',
             },
           ],
           category: ['BROWSABLE', 'DEFAULT'],

--- a/app/invite/[code].tsx
+++ b/app/invite/[code].tsx
@@ -1,0 +1,50 @@
+import { postInviteCode } from '@/api/myPageDTO';
+import { useAuthenticationStore } from '@/store/useAuthenticationStore';
+import { router, useLocalSearchParams } from 'expo-router';
+import React, { useEffect } from 'react';
+import { ActivityIndicator, Alert, View } from 'react-native';
+
+export default function AcceptInviteScreen() {
+  const { code } = useLocalSearchParams<{ code: string }>();
+  const { isAuthenticated } = useAuthenticationStore.getState(); // 훅 대신 getState 사용
+
+  useEffect(() => {
+    if (!code) {
+      // 잘못된 링크 처리
+      Alert.alert('잘못된 링크', '잘못된 링크입니다.', [{ text: '확인', onPress: () => router.replace('/sign-in') }]);
+      return;
+    }
+
+    if (isAuthenticated) {
+      // 1. 이미 로그인된 사용자인 경우
+      accept(code);
+    } else {
+      // 2. 로그인되지 않은 사용자인 경우
+      Alert.alert('로그인 필요', '친구 초대를 수락하려면 로그인이 필요합니다. 로그인 후 다시 링크를 클릭해주세요.', [
+        {
+          text: '로그인하기',
+          onPress: () => router.replace(`/sign-in`),
+        },
+      ]);
+    }
+  }, [code, isAuthenticated]);
+
+  const accept = async (code: string) => {
+    try {
+      const response = await postInviteCode({ code });
+      console.log('친구 추가 성공 결과', response);
+      Alert.alert('성공!', `친구가 추가되었습니다.`, [
+        { text: '확인', onPress: () => router.replace('/mypage/friend') },
+      ]);
+    } catch (error) {
+      console.log('친구 추가 실패 결과', error);
+    }
+  };
+
+  // 처리 중에는 로딩 인디케이터만 표시
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}

--- a/components/common/Modal/DefaultModal.tsx
+++ b/components/common/Modal/DefaultModal.tsx
@@ -1,6 +1,7 @@
 import { ButtonSize, ButtonVariant } from '@/constants/buttonTypes';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import Toast from 'react-native-toast-message';
 import { PrimaryButton } from '../Button/PrimaryButton';
 
 interface DefaultModalProps {
@@ -31,43 +32,34 @@ interface DefaultModalProps {
 /**
  * 하단 버튼, 옵션을 제공하는 기본 모달 컴포넌트
  */
-export default function DefaultModal({
-  title,
-  desc,
-  children,
-  buttons,
-  options,
-}: DefaultModalProps) {
+export default function DefaultModal({ title, desc, children, buttons, options }: DefaultModalProps) {
   return (
-    <View style={styles.container}>
-      <View>
-        <Text style={styles.title}>{title}</Text>
-        {desc && <Text style={styles.desc}>{desc}</Text>}
-      </View>
-      {children}
-
-      {buttons && (
-        <PrimaryButton
-          variant={ButtonVariant.Primary}
-          text={buttons.text}
-          onPress={buttons.onPress}
-        />
-      )}
-
-      {options && (
-        <View style={styles.optionsWrapper}>
-          {options.map((option, idx) => (
-            <PrimaryButton
-              key={idx}
-              variant={option.variant}
-              size={ButtonSize.Small}
-              text={option.text}
-              onPress={option.onPress}
-            />
-          ))}
+    <>
+      <View style={styles.container}>
+        <View>
+          <Text style={styles.title}>{title}</Text>
+          {desc && <Text style={styles.desc}>{desc}</Text>}
         </View>
-      )}
-    </View>
+        {children}
+
+        {buttons && <PrimaryButton variant={ButtonVariant.Primary} text={buttons.text} onPress={buttons.onPress} />}
+
+        {options && (
+          <View style={styles.optionsWrapper}>
+            {options.map((option, idx) => (
+              <PrimaryButton
+                key={idx}
+                variant={option.variant}
+                size={ButtonSize.Small}
+                text={option.text}
+                onPress={option.onPress}
+              />
+            ))}
+          </View>
+        )}
+      </View>
+      <Toast />
+    </>
   );
 }
 

--- a/components/mypage/LinkContainer.tsx
+++ b/components/mypage/LinkContainer.tsx
@@ -1,17 +1,32 @@
+import { getInviteLink } from '@/api/myPageDTO';
 import IconCopy from '@/assets/icons/icon-copy.svg';
 import { MCOLORS } from '@/constants/colors';
 import { fontStyles } from '@/constants/fonts';
+import { showSuccessToast } from '@/utils/toastManager';
 import * as Clipboard from 'expo-clipboard';
+import { useLayoutEffect, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 export default function LinkContainer() {
+  const [inviteLink, setInviteLink] = useState<string>('');
+  useLayoutEffect(() => {
+    getInviteLink()
+      .then(res => {
+        setInviteLink(res.result.url);
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  }, []);
+
   const copyToClipboard = async () => {
-    await Clipboard.setStringAsync('https://www.melog.com/invite/123');
+    await Clipboard.setStringAsync(inviteLink);
+    showSuccessToast('초대링크를 복사했어요.');
   };
 
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>https://www.melog.com/invite/123</Text>
+      <Text style={styles.text}>{inviteLink}</Text>
       <Pressable onPress={copyToClipboard}>
         <IconCopy />
       </Pressable>

--- a/components/template/MyPageFriendTemplate.tsx
+++ b/components/template/MyPageFriendTemplate.tsx
@@ -1,4 +1,4 @@
-import { deleteMyFriend, getFriendProfile } from "@/api/myPageDTO";
+import { deleteMyFriend, getFriendProfile } from '@/api/myPageDTO';
 import { FriendProfileResponse } from '@/api/type';
 import IconAddFriend from '@/assets/icons/icon-addFriend.svg';
 import { TopBar } from '@/components/common/TopBar';
@@ -26,7 +26,7 @@ export default function MyPageFriendTemplate({
   const handleOpenInviteModal = () => {
     onOpenInviteModal(ModalType.DEFAULT, {
       title: '친구 추가',
-      desc: '아래의 링크를 복사해 초대할 친구에게 보내주세요',
+      desc: '아래의 링크를 복사해 초대할 친구에게 전송하세요',
       options: [
         { variant: ButtonVariant.Subtle, text: '취소', onPress: onCloseInviteModal },
         { variant: ButtonVariant.Primary, text: '공유하기', onPress: shareLink },

--- a/ios/Mellog/Mellog.entitlements
+++ b/ios/Mellog/Mellog.entitlements
@@ -8,5 +8,9 @@
     <array>
       <string>Default</string>
     </array>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:mellog.vercel.app</string>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION
## #️⃣연관된 이슈

#98

## 📝작업 내용

- 친구 추가 링크 API 연동
- 친구 요청 수락을 담당하는 /invite 페이지 추가 및 친구 수락 API 구현
- 안드로이드/ios deeplink 구현 완료
- 안드로이드 에러 발생 원인
Manifest 파일에서 intent-filter 속 
`      <intent-filter android:autoVerify="true" data-generated="true">
        <action android:name="android.intent.action.VIEW"/>  
        <category android:name="android.intent.category.BROWSABLE"/>
        <category android:name="android.intent.category.DEFAULT"/>
        <data android:scheme="https" android:host="mellog.vercel.app" android:pathPrefix="/invite"/>
      </intent-filter>`
      
      의 data 태그와 category 태그의 순서를 바뀌어 있던걸 위처럼 바꾸니 구동했습니다.


(+)
- 아직 친구 수락 api 작동 로직 테스트가 안됐습니다. 심사 올리고 테스트해봐야 합니다.
- 앱 설치 안되어 있으면 스토어로 가는 것을 구현해야 하는데 이것은 배포 후 할 수 있는 영역이라 배포 후 작업 진행합니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
